### PR TITLE
[Python] remove 3.8 support

### DIFF
--- a/Installation/With-PIP.md
+++ b/Installation/With-PIP.md
@@ -4,7 +4,7 @@ With Python index package (pip)
 Requirements
 ------------
 
--   Python 3.10 (recommended), 3.8 and 3.9 are also compatible ([download](https://www.python.org/downloads/))
+-   Python 3.10 (recommended), 3.9 is also compatible ([download](https://www.python.org/downloads/))
 -   Add python to your PATH ([tutorial windows](https://superuser.com/questions/143119/how-do-i-add-python-to-the-windows-path))
 
 Installation

--- a/Installation/With-Python-only.md
+++ b/Installation/With-Python-only.md
@@ -9,7 +9,7 @@ Requirements
 Installation
 ------------
 
-**First, make sure you have python3.10 and python3.10-dev and python3.10-pip installed on your computer.** Python 3.8 and 3.9 installations also work but are slower and not recommended.
+**First, make sure you have python3.10 and python3.10-dev and python3.10-pip installed on your computer.** Python 3.9 installations also work but are slower and not recommended.
 
 ### Using the current stable version (master branch)
 


### PR DESCRIPTION
Requires OctoBot 0.4.53 release